### PR TITLE
Added knot_zone and knot_zone_stats metrics

### DIFF
--- a/knot_exporter
+++ b/knot_exporter
@@ -9,6 +9,7 @@ import argparse
 import http.server
 
 from libknot.control import *
+import re
 
 from prometheus_client.core import REGISTRY
 from prometheus_client.core import GaugeMetricFamily
@@ -29,6 +30,26 @@ class KnotCollector(object):
         load_lib(lib)
         self._sock = sock
         self._ttl = ttl
+
+    def convert_state_time(time):
+
+        if time == "pending" or time == "running":
+            return 0
+        elif time == "not scheduled":
+            return None
+        else:
+            match = re.match("([+-])((\d+)D)?((\d+)h)?((\d+)m)?((\d+)s)?", time)
+            seconds = -1 if match.group(1) == '-' else 1
+            if match.group(3):
+                seconds = seconds + 86400 * int(match.group(3))
+            if match.group(5):
+                seconds = seconds + 3600 * int(match.group(5))
+            if match.group(7):
+                seconds = seconds + 60 * int(match.group(7))
+            if match.group(9):
+                seconds = seconds + int(match.group(9))
+
+        return seconds
 
     def collect(self):
         ctl = KnotCtl()
@@ -79,6 +100,46 @@ class KnotCollector(object):
                                     labels=['zone', 'section'])
                             m.add_metric([zone, section], item_data)
                             yield m
+
+        # zone state metrics
+        ctl.send_block(cmd="zone-status")
+        zone_states = ctl.receive_block()
+
+        for zone, info in zone_states.items():
+
+            metrics = ['expiration', 'refresh']
+
+            for metric in metrics:
+
+                seconds = KnotCollector.convert_state_time(info[metric])
+                if seconds == None:
+                    continue
+
+                m = GaugeMetricFamily('knot_zone_stats_' + metric, '', labels=['zone'])
+                m.add_metric([zone], seconds)
+
+                yield m
+
+        # zone configuration metrics
+        ctl.send_block(cmd="zone-read", rtype="SOA")
+        zones = ctl.receive_block()
+
+        for name, params in zones.items():
+
+            metrics = [
+                {"name": "knot_zone_refresh",    "index": 3},
+                {"name": "knot_zone_retry",      "index": 4},
+                {"name": "knot_zone_expiration", "index": 5},
+            ]
+
+            zone_config = params[name]['SOA']['data'][0].split(" ")
+
+            for metric in metrics:
+
+                m = GaugeMetricFamily(metric['name'], '', labels=['zone'])
+                m.add_metric([name], int(zone_config[metric['index']]))
+
+                yield m
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(


### PR DESCRIPTION
HI,

this MR adds new metrics with zone status and zone configuration values:

- `knot_zone_retry` - configured zone RETRY value
- `knot_zone_expiration` - configured zone EXPIRE value
- `knot_zone_refresh` - configured zone REFRESH value
- `knot_zone_stats_expiration` - remaining time to zone expiration
- `knot_zone_stats_refresh` - remaining time to zone refresh

All metrics have just `zone` label.

They can be use to construct zone refresh and zone expiration alerts:

```
groups:
- name: dns-knot
  rules:
  - alert: knot zone refresh overdue
    expr: |
        (knot_zone_expiration - knot_zone_stats_expiration > knot_zone_refresh) # compute whether we're overdue
        and
        (knot_zone_stats_refresh != 0) # eliminate pending/running zone update false positives
    labels:
      severity: warning
    annotations:
      title: 'Knot zone refresh overdue'
      description: 'Knot zone {{$labels.zone}} has not been refreshed on {{ $labels.hostname }}'

  - alert: knot zone is not served
    expr: | # alert on zones that are known by knot and no expiration is available
        knot_zone_stats_refresh
        unless
        knot_zone_expiration
    labels:
      severity: critical
    annotations:
      title: 'Knot zone is not served'
      description: "Knot doesn't serve {{$labels.zone}} on {{ $labels.hostname }}"
```